### PR TITLE
FEAT: impl solution without graph

### DIFF
--- a/single-bar/LucasTrindade/solution5.py
+++ b/single-bar/LucasTrindade/solution5.py
@@ -1,0 +1,17 @@
+def max_price(bar_size:int, price_map:list)->int|bool:
+    if (bar_size < 1
+        or len(price_map) < 1
+        or bar_size != len(price_map)
+    ):
+        return False
+    
+    prices = [0] * (bar_size + 1)
+      
+    for source in range(bar_size, -1, -1):
+        max_price_for_item = 0
+        for step in range(source+1, bar_size+1):
+            price = price_map[(step-source-1)] + prices[step]
+            max_price_for_item = max(max_price_for_item, price)
+        prices[source] = max_price_for_item
+
+    return prices[0]

--- a/single-bar/LucasTrindade/tests.py
+++ b/single-bar/LucasTrindade/tests.py
@@ -6,7 +6,8 @@ import time
 #from solution1 import max_price #dfs 
 #from solution2 import max_price #dfs + dp 
 #from solution3 import max_price #dfs + dp v2
-from solution4 import max_price #dfs + dp v2 + divide to conquer
+#from solution4 import max_price #dfs + dp v2 + divide to conquer
+from solution5 import max_price #dfs + dp v2 + divide to conquer
 
 ####################################################################
 ### asserts 


### PR DESCRIPTION
Fiz uma solução sem utilizar o grafo, para reduzir a complexidade de tempo e espaço (principalmente). Ficou bem parecida com a lógica da Caroline. Sem a recursão, a execução não consome mais toda a memória RAM e calcula o maior valor para 100mil pedaços em 17 minutos.